### PR TITLE
Fix note preview dynamics

### DIFF
--- a/src/appshell/qml/Preferences/internal/NoteInput/NotePreviewSection.qml
+++ b/src/appshell/qml/Preferences/internal/NoteInput/NotePreviewSection.qml
@@ -34,7 +34,7 @@ BaseSection {
     property alias playChordSymbolWhenEditing: playChordSymbolBox.checked
     property alias playPreviewNotesInInputByDuration: playPreviewNotesInInputByDurationBox.checked
     property alias notePlayDurationMilliseconds: notePlayDurationControl.currentValue
-    property int notePreviewVolume: 100
+    property int notePreviewVolume: 48
 
     property alias playNotesOnMidiInput: playNotesOnMidiInputBox.checked
     property alias playNotesOnMidiInputBoxEnabled: playNotesOnMidiInputBox.enabled
@@ -133,6 +133,7 @@ BaseSection {
         currentIndex: previewVolumeDropdown.indexOfValue(root.notePreviewVolume)
 
         onValueEdited: function(newIndex, newValue) {
+            root.notePreviewVolume = newValue
             root.notePreviewVolumeChangeRequested(newValue)
         }
     }

--- a/src/playback/internal/playbackconfiguration.cpp
+++ b/src/playback/internal/playbackconfiguration.cpp
@@ -129,7 +129,7 @@ void PlaybackConfiguration::init()
         m_muteHiddenInstrumentsChanged.send(mute.toBool());
     });
 
-    settings()->setDefaultValue(NOTE_PREVIEW_VOLUME, Val(100));
+    settings()->setDefaultValue(NOTE_PREVIEW_VOLUME, Val(48));
     settings()->valueChanged(NOTE_PREVIEW_VOLUME).onReceive(this, [this](const Val& val) {
         MScore::notePreviewVolume = val.toInt();
         m_notePreviewVolumeChanged.send(val.toInt());


### PR DESCRIPTION
## Summary
- set `notePreviewVolume` default to `mp`
- keep dropdown value synced with the property

## Testing
- `cmake ..` *(fails: could not find Qt6)*

------
https://chatgpt.com/codex/tasks/task_e_684806261e608323b1a659e95428a82e