### PR TITLE
Fix preview volume update

### DIFF
--- a/src/engraving/playback/playbackmodel.cpp
+++ b/src/engraving/playback/playbackmodel.cpp
@@ -35,6 +35,7 @@
 #include "dom/tie.h"
 #include "dom/tremolotwochord.h"
 #include "dom/mscore.h"
+#include "playback/iplaybackconfiguration.h"
 
 #include "log.h"
 
@@ -70,6 +71,11 @@ void PlaybackModel::load(Score* score)
     }
 
     m_score = score;
+
+    m_notePreviewVolume = playbackConfiguration()->notePreviewVolume();
+    playbackConfiguration()->notePreviewVolumeChanged().onReceive(this, [this](int val) {
+        m_notePreviewVolume = val;
+    });
 
     auto changesChannel = score->changesChannel();
     changesChannel.resetOnReceive(this);
@@ -251,7 +257,7 @@ void PlaybackModel::triggerEventsForItems(const std::vector<const EngravingItem*
     const RepeatList& repeats = repeatList();
 
     timestamp_t actualTimestamp = 0;
-    dynamic_level_t actualDynamicLevel = dynamicLevelFromType(muse::mpe::DynamicType::Natural) * MScore::notePreviewVolume / 100;
+    dynamic_level_t actualDynamicLevel = dynamicLevelFromType(muse::mpe::DynamicType::Natural) * m_notePreviewVolume / 100;
     duration_t actualDuration = MScore::defaultPlayDuration * 1000;
 
     const PlaybackContextPtr ctx = playbackCtx(trackId);

--- a/src/engraving/playback/playbackmodel.h
+++ b/src/engraving/playback/playbackmodel.h
@@ -34,6 +34,7 @@
 #include "modularity/ioc.h"
 #include "mpe/events.h"
 #include "mpe/iarticulationprofilesrepository.h"
+#include "playback/iplaybackconfiguration.h"
 
 #include "../types/types.h"
 #include "playbackeventsrenderer.h"
@@ -52,6 +53,7 @@ class PlaybackModel : public muse::Injectable, public muse::async::Asyncable
 {
 public:
     muse::Inject<muse::mpe::IArticulationProfilesRepository> profilesRepository = { this };
+    muse::Inject<mu::playback::IPlaybackConfiguration> playbackConfiguration = { this };
 
 public:
     PlaybackModel(const muse::modularity::ContextPtr& iocCtx)
@@ -164,6 +166,8 @@ private:
 
     std::unordered_map<InstrumentTrackId, PlaybackContextPtr> m_playbackCtxMap;
     std::unordered_map<InstrumentTrackId, muse::mpe::PlaybackData> m_playbackDataMap;
+
+    int m_notePreviewVolume = 48;
 
     muse::async::Notification m_dataChanged;
     muse::async::Channel<InstrumentTrackId> m_trackAdded;


### PR DESCRIPTION
## Summary
- listen to preview volume changes
- use the configured preview volume when rendering previews

## Testing
- `./hooks/pre-commit`

------
https://chatgpt.com/codex/tasks/task_e_68480a5464ac832396d6edbeb2418be4