### PR TITLE
Fix preview volume control

### DIFF
--- a/src/engraving/playback/playbackmodel.cpp
+++ b/src/engraving/playback/playbackmodel.cpp
@@ -257,7 +257,7 @@ void PlaybackModel::triggerEventsForItems(const std::vector<const EngravingItem*
     const RepeatList& repeats = repeatList();
 
     timestamp_t actualTimestamp = 0;
-    dynamic_level_t actualDynamicLevel = dynamicLevelFromType(muse::mpe::DynamicType::Natural) * m_notePreviewVolume / 100;
+    dynamic_level_t actualDynamicLevel = m_notePreviewVolume * muse::mpe::ONE_PERCENT;
     duration_t actualDuration = MScore::defaultPlayDuration * 1000;
 
     const PlaybackContextPtr ctx = playbackCtx(trackId);


### PR DESCRIPTION
## Summary
- fix note preview volume scaling to match dynamic units

## Testing
- `cmake -P build.cmake -DCMAKE_BUILD_TYPE=Release` *(fails: Unable to find Qt)*

------
https://chatgpt.com/codex/tasks/task_e_68480f058d98832395b0581ca8810525